### PR TITLE
Agregando return sequelize.sync(); 

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,11 @@ sequelize
   .authenticate()
   .then(() => {
     console.log("Conexión a la base de datos exitosa");
+
+    // Sincronizar modelos con la base de datos
+    return sequelize.sync(); // `alter: true` asegura que las tablas se adapten a cambios en los modelos
+  })
+  .then(() => {
     app.listen(3000, () => {
       console.log("Servidor corriendo en el puerto 3000");
     });


### PR DESCRIPTION
Con el fin de evitar crear tablas previamente, sino al momento de cargar el servicio de la API